### PR TITLE
[TASK] Added zend-stdlib to ignore on compile run

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,6 +7,7 @@ TYPO3:
         'zendframework.zendcode': ['.*']
         'react.promise': ['.*']
         'zendframework.zendmath': ['.*']
+        'zendframework.zendstdlib': ['.*']
     reflection:
       ignoredTags:
         unstable: 'unstable'


### PR DESCRIPTION
The autoload.php of zendframework.zendstdlib triggers an deprecated error
