### PR TITLE
TASK: Update settings for Flow 3.0 (Neos 2.0)

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,16 +1,8 @@
 TYPO3:
   Flow:
-    object:
-      excludeClasses:
-        'zendframework.zendcache': ['.*']
-        'zendframework.zendconfig': ['.*']
-        'zendframework.zendcode': ['.*']
-        'react.promise': ['.*']
-        'zendframework.zendmath': ['.*']
-        'zendframework.zendstdlib': ['.*']
     reflection:
       ignoredTags:
-        unstable: 'unstable'
+        unstable: TRUE
 
   Neos:
     typoScript:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "typo3/neos": "*",
+        "typo3/neos": "^2.0",
         "heise/shariff": "~1.5"
     },
     "autoload": {


### PR DESCRIPTION
Includes #11 

Requires new major release because Neos `^2.0` is required (instead of disfavored `*`).