### PR TITLE
BUGFIX: Declare json as supported media type

### DIFF
--- a/Classes/Controller/ShariffController.php
+++ b/Classes/Controller/ShariffController.php
@@ -12,6 +12,11 @@ use Neos\Flow\Mvc\Controller\ActionController;
 class ShariffController extends ActionController
 {
     /**
+     * @var string[]
+     */
+    protected $supportedMediaTypes = ['application/json'];
+
+    /**
      * @var Backend
      * @Flow\Inject
      */


### PR DESCRIPTION
I just realized that every XHR request to the backend is getting a `406` without this patch...