### PR TITLE
TASK: Declare compatible with Neos 8 and Flow 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "guzzlehttp/psr7": "^1.3.0",
+        "php": "^7.4 || ^8.0",
+        "guzzlehttp/psr7": "^1.8.4 || ^2.1.1",
         "heise/shariff": "^8.0",
-        "neos/neos": "^4.0 || ^5.0 || ^7.0",
-        "neos/utility-files": "^5.0 || ^6.0 || ^7.0"
+        "neos/neos": "^5.3 || ^7.0 || ^8.0",
+        "neos/utility-files": "^6.3 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/psr7": "^1.8.4 || ^2.1.1",
-        "heise/shariff": "^8.0",
+        "heise/shariff": "^10.0",
         "neos/neos": "^5.3 || ^7.0 || ^8.0",
         "neos/utility-files": "^6.3 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
This drops compatibility with Neos < 5.3 / Flow < 6.3 and raises the
minimum PHP version to 7.4